### PR TITLE
Configure DMA for hardware channels 2 and 3

### DIFF
--- a/E_couple/generate/include/Dma_Ip_Cfg.h
+++ b/E_couple/generate/include/Dma_Ip_Cfg.h
@@ -115,6 +115,12 @@ extern "C"
 /* Logic Channel 1 */
 #define DMA_LOGIC_CH_1   ((uint8)1U)
 
+/* Logic Channel 2 */
+#define DMA_LOGIC_CH_2   ((uint8)2U)
+
+/* Logic Channel 3 */
+#define DMA_LOGIC_CH_3   ((uint8)3U)
+
 #define MCL_START_SEC_CONFIG_DATA_UNSPECIFIED
 /* @violates @ref Mcl_Dma_h_REF_1 MISRA 2012 Required Directive 4.10, Precautions shall be taken in order to prevent the contents of a header file being included more than once. */
 #include "Mcl_MemMap.h"

--- a/E_couple/generate/src/Dma_Ip_VS_0_PBcfg.c
+++ b/E_couple/generate/src/Dma_Ip_VS_0_PBcfg.c
@@ -220,14 +220,14 @@ extern void Lpuart_3_Uart_Ip_DmaTxCompleteCallback(void);
 
 const Dma_Ip_LogicChannelConfigType LogicChannel0ConfigPB = 
 {
-		{
-				/* uint32 LogicChId; */               DMA_LOGIC_CH_0,
-				/* uint8 HwVersId; */                 DMA_IP_HARDWARE_VERSION_3,
-				/* uint8 HwInst; */                   DMA_IP_HW_INST_0,
-				/* uint8 HwChId; */                   0U,
-				/* Dma_Ip_Callback IntCallback; */    Lpuart_3_Uart_Ip_DmaTxCompleteCallback,
-				/* Dma_Ip_Callback ErrIntCallback; */ NULL_PTR,
-		}, /* Dma_Ip_LogicChannelIdType */
+                {
+                                /* uint32 LogicChId; */               DMA_LOGIC_CH_2,
+                                /* uint8 HwVersId; */                 DMA_IP_HARDWARE_VERSION_3,
+                                /* uint8 HwInst; */                   DMA_IP_HW_INST_0,
+                                /* uint8 HwChId; */                   2U,
+                                /* Dma_Ip_Callback IntCallback; */    Lpuart_3_Uart_Ip_DmaTxCompleteCallback,
+                                /* Dma_Ip_Callback ErrIntCallback; */ NULL_PTR,
+                }, /* Dma_Ip_LogicChannelIdType */
 		&LogicChannel0GlobalConfigPB,
 		NULL_PTR,
 		NULL_PTR,
@@ -237,14 +237,14 @@ extern void Lpuart_3_Uart_Ip_DmaRxCompleteCallback(void);
 
 const Dma_Ip_LogicChannelConfigType LogicChannel1ConfigPB = 
 {
-		{
-				/* uint32 LogicChId; */               DMA_LOGIC_CH_1,
-				/* uint8 HwVersId; */                 DMA_IP_HARDWARE_VERSION_3,
-				/* uint8 HwInst; */                   DMA_IP_HW_INST_0,
-				/* uint8 HwChId; */                   1U,
-				/* Dma_Ip_Callback IntCallback; */    Lpuart_3_Uart_Ip_DmaRxCompleteCallback,
-				/* Dma_Ip_Callback ErrIntCallback; */ NULL_PTR,
-		}, /* Dma_Ip_LogicChannelIdType */
+                {
+                                /* uint32 LogicChId; */               DMA_LOGIC_CH_3,
+                                /* uint8 HwVersId; */                 DMA_IP_HARDWARE_VERSION_3,
+                                /* uint8 HwInst; */                   DMA_IP_HW_INST_0,
+                                /* uint8 HwChId; */                   3U,
+                                /* Dma_Ip_Callback IntCallback; */    Lpuart_3_Uart_Ip_DmaRxCompleteCallback,
+                                /* Dma_Ip_Callback ErrIntCallback; */ NULL_PTR,
+                }, /* Dma_Ip_LogicChannelIdType */
 		&LogicChannel1GlobalConfigPB,
 		NULL_PTR,
 		NULL_PTR,
@@ -264,11 +264,11 @@ const Dma_Ip_LogicChannelConfigType * const Dma_Ip_paxLogicChannelConfigArrayPB[
 /* @violates @ref Mcl_Dma_h_REF_1 MISRA 2012 Required Directive 4.10, Precautions shall be taken in order to prevent the contents of a header file being included more than once. */
 #include "Mcl_MemMap.h"
 
-/* DMA Hardware Channel 0 */
-Dma_Ip_HwChannelStateType HwChannel0StatePB;
+/* DMA Hardware Channel 2 */
+Dma_Ip_HwChannelStateType HwChannel2StatePB;
 
-/* DMA Hardware Channel 1 */
-Dma_Ip_HwChannelStateType HwChannel1StatePB;
+/* DMA Hardware Channel 3 */
+Dma_Ip_HwChannelStateType HwChannel3StatePB;
 
 #define MCL_STOP_SEC_VAR_CLEARED_UNSPECIFIED_NO_CACHEABLE
 /* @violates @ref Mcl_Dma_h_REF_1 MISRA 2012 Required Directive 4.10, Precautions shall be taken in order to prevent the contents of a header file being included more than once. */
@@ -281,8 +281,8 @@ Dma_Ip_HwChannelStateType HwChannel1StatePB;
 /* DMA Hardware Channel State and DMA Logic Channel Configuration Array */
 Dma_Ip_HwChannelStateType * Dma_Ip_paxHwChannelStateArrayPB[DMA_IP_NOF_CFG_LOGIC_CHANNELS] =
 {
-		&HwChannel0StatePB,
-		&HwChannel1StatePB,
+                &HwChannel2StatePB,
+                &HwChannel3StatePB,
 };
 
 #define MCL_STOP_SEC_VAR_INIT_UNSPECIFIED_NO_CACHEABLE

--- a/E_couple/src/main.c
+++ b/E_couple/src/main.c
@@ -102,11 +102,11 @@ int main(void)
 
     Dma_Ip_Init(&Dma_Ip_xDmaInitPB);
 
-    IP_DMAMUX_1->CHCFG[3]=0xA8;
-    IP_TCD->CH0_CSR=1;
+    IP_DMAMUX_1->CHCFG[2] = 0xA8U;
+    IP_TCD->CH2_CSR = 1U;
 
-    IP_DMAMUX_1->CHCFG[2]=0xA9;
-    IP_TCD->CH1_CSR=1;
+    IP_DMAMUX_1->CHCFG[3] = 0xA9U;
+    IP_TCD->CH3_CSR = 1U;
 
     eINITState = checkSbcInitState();
     printf("FS23 STATE is %s\r\n", eINITState == SBC_Init_INIT_STATE ? "INIT STATE" : (eINITState == SBC_Init_NON_INIT_STATE ? "Not INIT STATE" : "INVALID"));


### PR DESCRIPTION
## Summary
- map DMA logic channels to hardware channels 2 and 3
- align DMAMUX and TCD CSR indices with new DMA channels
- expose logic channel IDs 2 and 3 in configuration

## Testing
- `make -C Debug_FLASH` *(fails: multiple target patterns)*

------
https://chatgpt.com/codex/tasks/task_e_68ac09fe25f0832c8bdb094522e6a092